### PR TITLE
FR1.0.9 - Event 'More Info' buttons fixed

### DIFF
--- a/GoPlayMobile/app/event/[eventId].tsx
+++ b/GoPlayMobile/app/event/[eventId].tsx
@@ -19,7 +19,7 @@ const eventDetails: EventDetails = {
     description: "Join us to see who can tackle the most slices of our delicious pizza pies. You never lose with great pizza, but the best eater gets free slices for a year!",
   },
   '3': {
-    title: "Open Mic Nite at the Union Club Bar & Grill",
+    title: "Union Club Bar & Grill: Open Mic Nite",
     description: "Calling all local talent for a fun-filled evening at the Union Club's Open Mic Nite. All talents welcome, so let's sing and dance the night away!",
   },
 };

--- a/GoPlayMobile/app/master.tsx
+++ b/GoPlayMobile/app/master.tsx
@@ -15,7 +15,7 @@ const INITIAL_REGION = {
 const LOCATIONS = [
   { id: '1', name: 'Rudy\'s Poetry Contest', latitude: 46.8624, longitude: -114.0160 },
   { id: '2', name: 'Shut Your Pie Hole (Eating Contest)', latitude: 46.8749, longitude: -113.9925 },
-  { id: '3', name: 'Open Mic Nite at the Union Club Bar & Grill', latitude: 46.8708, longitude: -113.9925 },
+  { id: '3', name: 'Union Club Bar & Grill: Open Mic Nite', latitude: 46.8708, longitude: -113.9925 },
 ];
 
 const SCREEN_HEIGHT = Dimensions.get("window").height;
@@ -88,7 +88,7 @@ const Master = () => {
             keyExtractor={item => item.id}
             renderItem={({ item }) => (
               <View style={styles.listItem}>
-                <TouchableOpacity onPress={() => handlePress(item)}>
+                <TouchableOpacity onPress={() => handlePress(item)} style={styles.textContainer}>
                   <Text style={styles.locationText}>{item.name}</Text>
                 </TouchableOpacity>
                 <Button title="More Info" onPress={() => handleMoreInfo(item.id)} />
@@ -128,6 +128,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingHorizontal: 20,
     paddingVertical: 10,
+  },
+  textContainer: {
+    flex: 1,
+    marginRight: 10,
   },
   locationText: {
     fontSize: 18,


### PR DESCRIPTION
Fixed 'More Info' buttons to be a little smaller and event text to wrap sooner. This prevents them from being cut off on the app screen and only partially displaying (see attached photos). in order to get it to run you will need to run the following command 'npm install expo-router'. If it still doesn't work you may also need to run 'npm install react-router-dom' and 'npm install @types/react-router-dom'. But try just running the first command as the others seem related to a previous import statement that I removed so they shouldn't be necessary.
![Screenshot_20250223-191048](https://github.com/user-attachments/assets/a706068e-7d31-4a53-bfe6-96c4ba9db917)
![Screenshot_20250223-191027](https://github.com/user-attachments/assets/a9f292e3-d23b-4a8d-b3a8-ca4cb70b9b03)
